### PR TITLE
Address set-output Deprecation (PAYINP-1626)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
             BRANCH=$(echo ${{ github.ref }} | sed 's/refs\/heads\///');
         fi;
         echo "Determined branch: $BRANCH"
-        echo "::set-output name=branch_name::$BRANCH";
+        echo "branch_name=$BRANCH" >> $GITHUB_OUTPUT;
 
     - name: "Sanitize Branch name"
       id: sanitize_branch
@@ -27,5 +27,5 @@ runs:
       run: |
         SANITIZED_BRANCH_NAME=$(echo -n ${{ steps.determine_branch.outputs.branch_name }} | tr "/" "-")
         echo "Sanitized branch name: $SANITIZED_BRANCH_NAME"
-        echo ::set-output name=sanitized_branch_name::$SANITIZED_BRANCH_NAME;
+        echo "sanitized_branch_name=$SANITIZED_BRANCH_NAME" >> $GITHUB_OUTPUT;
 


### PR DESCRIPTION
## Context

Rework usage of the set-output command to instead use the new approach involving piping to $GITHUB_OUTPUT, as set-output is deprecated and will be removed at some point in the future.

Note I don't think this warrants a v2 tag, probably best to re-tag the change as v1, so that current consumers of the action don't all have to bump the version. I don't believe there are backwards compatibility issues with it. 

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
