### PR TITLE
Move branch refs to environment variables

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,10 +13,12 @@ runs:
     - name: "Determine Branch"
       id: determine_branch
       shell: bash
+      env:
+        BRANCH: ${{ github.head_ref }}
+        REF: ${{ github.ref }}
       run: |
-        BRANCH=${{ github.head_ref }}
         if [ "$BRANCH" == "" ]; then
-            BRANCH=$(echo ${{ github.ref }} | sed 's/refs\/heads\///');
+            BRANCH=$(echo $REF | sed 's/refs\/heads\///');
         fi;
         echo "Determined branch: $BRANCH"
         echo "branch_name=$BRANCH" >> $GITHUB_OUTPUT;


### PR DESCRIPTION
Using branch names as part of the bash command can have security implications, since the user (potential attacker) can control the name of the branch and submit code from a branch like
```
my-branch-$(.${IFS}pwn.sh)
```
and execute code as a result.

## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->

## Checklist
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
